### PR TITLE
Fix/stream controller dependencies into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 (2017-08-20)
+Fixed:
+  * Expose PORT 3000 on docker image.
+  * StreamController dependencies are no correctly injected.
+
 ## 1.0.0 (2017-08-20)
 
 Features:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ RUN npm install && \
 
 ENV PORT 3000
 
+EXPOSE 3000
+
 CMD npm start

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-audio-streamer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Youtube audio streamer",
   "main": "dist/server.js",
   "scripts": {

--- a/src/common/log/log.module.ts
+++ b/src/common/log/log.module.ts
@@ -1,8 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Module, Shared } from '@nestjs/common';
 import { LoggerService } from './logger.service';
 
+@Shared()
 @Module({
     components: [ LoggerService ],
+    exports: [ LoggerService ],
 })
 export class LogModule {
 


### PR DESCRIPTION
Fix:

* Expose port 3000 on in docker image.
* Export logger service in log module so it can be injected in component of other modules.
* Raise version number to 1.0.1

Resolves #19 